### PR TITLE
Fix case terminator in dependency script

### DIFF
--- a/wifipen_debug/dependencies.sh
+++ b/wifipen_debug/dependencies.sh
@@ -98,7 +98,7 @@ build_john_from_source() {
   case "$arch" in
     x86_64) flags+=" --enable-opencl" ;;
     aarch64|arm*) : ;; # OpenCL optional on ARM; keep off unless user sets it up
-  end
+  esac
   if ! ./configure $flags; then log "${RED}[!] John configure failed.${NC}"; return 1; fi
   make -j"$(nproc 2>/dev/null || echo 1)" && sudo make install
   sudo cp -f ../run/john /usr/local/bin/john


### PR DESCRIPTION
## Summary
- Corrected a `case` block in `dependencies.sh` that was terminated with `end` instead of `esac`.
- Ensures John the Ripper build step runs without syntax errors during dependency setup.

## Testing
- `bash -n wifipen_debug/dependencies.sh`


------
https://chatgpt.com/codex/tasks/task_e_689f63530c00832f9900f51f4a1aa188