### PR TITLE
Harden Bluetooth audit script

### DIFF
--- a/bl_audit/bl_audit.sh
+++ b/bl_audit/bl_audit.sh
@@ -30,10 +30,12 @@ echo -e "${YELLOW}Use only on devices and networks you are explicitly authorized
 echo ""
 
 # Check for root privileges
+SUDO=""
 if [[ $EUID -ne 0 ]]; then
     echo -e "${RED}Skrip ini memerlukan hak akses root untuk operasi Bluetooth.${NC}"
     echo -e "${YELLOW}Mencoba mendapatkan hak akses sudo...${NC}"
     sudo -v || { echo -e "${RED}Hak akses sudo tidak diberikan. Keluar.${NC}"; exit 1; }
+    SUDO="sudo"
 fi
 
 # ========== HELPER FUNCTIONS ==========
@@ -41,9 +43,9 @@ log() {
     local ts="[$(date +"%H:%M:%S")]"
     local log_file="$LOG_DIR/bl_audit_$(date +"%F").log"
     if [[ ! -f "$log_file" ]]; then
-        sudo touch "$log_file"
-        sudo chown "$(whoami):$(whoami)" "$log_file"
-        sudo chmod 644 "$log_file"
+        $SUDO touch "$log_file"
+        $SUDO chown "$(whoami):$(whoami)" "$log_file"
+        $SUDO chmod 644 "$log_file"
     fi
     echo -e "$ts $*" | tee -a "$log_file" || true
 }
@@ -52,13 +54,13 @@ setup_directories() {
     local dirs=("$TMP_DIR" "$LOG_DIR" "$OUTPUT_DIR")
     for dir in "${dirs[@]}"; do
         if [[ ! -d "$dir" ]]; then
-            if ! sudo mkdir -p "$dir"; then
+            if ! $SUDO mkdir -p "$dir"; then
                 log "${RED}[!] Gagal membuat direktori: $dir${NC}"
                 exit 1
             fi
         fi
-        sudo chown -R "$(whoami):$(whoami)" "$dir"
-        sudo chmod -R 755 "$dir"
+        $SUDO chown -R "$(whoami):$(whoami)" "$dir"
+        $SUDO chmod -R 755 "$dir"
     done
 }
 
@@ -126,12 +128,16 @@ check_python_tools() {
 
 check_dependencies() {
     log "${YELLOW}[*] Memeriksa dependensi...${NC}"
+    if ! command -v apt-get >/dev/null 2>&1; then
+        log "${RED}[!] apt-get tidak ditemukan. Instal paket secara manual.${NC}"
+        return 1
+    fi
     local apt_packages=("bluez" "btscanner" "obexftp" "python3" "python3-pip" "pipx")
-    sudo apt-get update
+    $SUDO apt-get update
     for pkg in "${apt_packages[@]}"; do
         if ! dpkg -s "$pkg" 2>/dev/null | grep -q "Status: install ok installed"; then
             log "${YELLOW}[!] $pkg tidak ditemukan. Menginstal...${NC}"
-            sudo apt-get install -y "$pkg" || log "${RED}[!] Gagal menginstal $pkg.${NC}"
+            $SUDO apt-get install -y "$pkg" || log "${RED}[!] Gagal menginstal $pkg.${NC}"
         fi
     done
     check_tool_version bluez "5.50" || log "${YELLOW}[!] Versi bluez mungkin tidak kompatibel.${NC}"
@@ -145,7 +151,7 @@ check_dependencies() {
     fi
     check_python_tools bluesnarfer bluesnarfer pybluez
     check_python_tools btlejack btlejack btlejack
-    local tools=(bluetoothctl btscanner obexftp bluesnarfer btlejack)
+    local tools=(bluetoothctl btscanner obexftp hcitool sdptool bluesnarfer btlejack)
     local missing=()
     for tool in "${tools[@]}"; do
         if ! is_tool_installed "$tool"; then


### PR DESCRIPTION
## Summary
- streamline privilege handling with a sudo helper variable
- verify apt-get availability and add explicit checks for bluetooth tooling

## Testing
- `for f in nfc_audit/*.sh wifi_audit/*.sh bl_audit/*.sh; do bash -n "$f"; done`
- `shellcheck bl_audit/bl_audit.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f67f9287c832f88c5bb1f5611809b