### PR TITLE
Improve handshake capture and cracking checks

### DIFF
--- a/wifi_audit/capture_handler.sh
+++ b/wifi_audit/capture_handler.sh
@@ -41,6 +41,20 @@ _deauth_or_scan_common_checks() {
   export NM_WAS_RUNNING="$nm_was_running"
 }
 
+# Validate that a capture file actually contains a WPA handshake
+verify_handshake() {
+  local capfile="$1" bssid="$2"
+  local tmp_hc="$TMP_DIR/verify_$(date +%s).hc22000"
+  if hcxpcapngtool -o "$tmp_hc" "$capfile" >/dev/null 2>&1 && [[ -s "$tmp_hc" ]]; then
+    if aircrack-ng -a2 -w /dev/null -b "$bssid" "$capfile" 2>&1 | grep -q "1 handshake"; then
+      rm -f "$tmp_hc"
+      return 0
+    fi
+  fi
+  rm -f "$tmp_hc" 2>/dev/null || true
+  return 1
+}
+
 deauth_only() {
   _deauth_or_scan_common_checks || return 1
 
@@ -331,31 +345,22 @@ scan_and_capture() {
       printf "\n"
     fi
 
-    # Check for handshake hint in log and attempt conversion for EAPOL confirmation
-    if [[ -f "$cap_file" ]] && grep -a -q "WPA handshake: $bssid" "$ad_log" 2>/dev/null; then
-      local tmp_hc="$TMP_DIR/test_$(date +%s).hc22000"
-      log "${YELLOW}[*] 'WPA handshake' line seen in airodump log; attempting conversion to confirm EAPOL...${NC}"
-      if hcxpcapngtool -o "$tmp_hc" "$cap_file" >/dev/null 2>&1 && [[ -s "$tmp_hc" ]]; then
-  # Clear terminal to remove any leftover airodump UI then print the banner
-  clear
-  echo
-  log "${GREEN}╔══════════════════════════════════════════════════════════════╗${NC}"
-        log "${GREEN}║                    HANDSHAKE CAPTURED!                       ║${NC}"
-        log "${GREEN}╚══════════════════════════════════════════════════════════════╝${NC}"
-        log "${GREEN}[+] SUCCESS: WPA handshake captured for network: $essid${NC}"
-        log "${GREEN}[+] BSSID: $bssid${NC}"
-        log "${GREEN}[+] Channel: $channel${NC}"
-        log "${GREEN}[+] Capture file: $cap_file${NC}"
-        log "${GREEN}[+] Conversion to hc22000 succeeded (EAPOL frames present).${NC}"
-        log "${GREEN}[+] Ready for cracking! Use Menu → Crack Handshake${NC}"
-        echo
-        # Pause to make sure user sees confirmation and any last log lines
-        read -r -p $'Handshake confirmed via conversion. Press Enter to stop capture and return to the menu...\n' _
-        rm -f "$tmp_hc"; found=1; break
-      else
-        log "${YELLOW}[!] Conversion attempt did not produce hc22000 (EAPOL not yet present). Continuing...${NC}"
-        rm -f "$tmp_hc" 2>/dev/null || true
-      fi
+    # Validate capture file for handshake on each iteration
+    if [[ -f "$cap_file" ]] && verify_handshake "$cap_file" "$bssid"; then
+      clear
+      echo
+      log "${GREEN}╔══════════════════════════════════════════════════════════════╗${NC}"
+      log "${GREEN}║                    HANDSHAKE CAPTURED!                       ║${NC}"
+      log "${GREEN}╚══════════════════════════════════════════════════════════════╝${NC}"
+      log "${GREEN}[+] SUCCESS: WPA handshake captured for network: $essid${NC}"
+      log "${GREEN}[+] BSSID: $bssid${NC}"
+      log "${GREEN}[+] Channel: $channel${NC}"
+      log "${GREEN}[+] Capture file: $cap_file${NC}"
+      log "${GREEN}[+] Ready for cracking! Use Menu → Crack Handshake${NC}"
+      echo
+      read -r -p $'Handshake confirmed. Press Enter to stop capture and return to the menu...\n' _
+      found=1
+      break
     fi
 
     printf "\r${CYAN}[*] Waiting for handshake... %ds${NC}" "$elapsed"

--- a/wifi_audit/crack_handler.sh
+++ b/wifi_audit/crack_handler.sh
@@ -69,7 +69,18 @@ run_john_wpa() {
   fi
 
   if [[ "$hashfile" == *.cap ]]; then
-    if is_tool_installed wpapcap2john; then
+    if [[ -n "${WPAPCAP2JOHN_BIN:-}" ]] && is_tool_installed "$WPAPCAP2JOHN_BIN"; then
+      john_hashfile="${hashfile%.cap}.john"
+      log "${YELLOW}[*] Converting .cap → .john ($WPAPCAP2JOHN_BIN) ...${NC}"
+      if ! "$WPAPCAP2JOHN_BIN" "$hashfile" > "$john_hashfile" 2>/dev/null || [[ ! -s "$john_hashfile" ]]; then
+        log "${YELLOW}[!] .cap→.john failed; trying .cap→.hc22000 (hcxpcapngtool)...${NC}"
+        john_hashfile="${hashfile%.cap}.hc22000"
+        if ! hcxpcapngtool -o "$john_hashfile" "$hashfile" >/dev/null 2>&1 || [[ ! -s "$john_hashfile" ]]; then
+          log "${RED}[!] Conversion failed. No valid handshake/PMKID?${NC}"
+          return 1
+        fi
+      fi
+    elif is_tool_installed wpapcap2john; then
       john_hashfile="${hashfile%.cap}.john"
       log "${YELLOW}[*] Converting .cap → .john (wpapcap2john) ...${NC}"
       if ! wpapcap2john "$hashfile" > "$john_hashfile" 2>/dev/null || [[ ! -s "$john_hashfile" ]]; then
@@ -170,7 +181,7 @@ _run_hashcat_22000() {
   fi
 
   # Baseline options
-  local -a hc_opts=(-m 22000 --status --status-timer=5 --potfile-path "${LOG_DIR}/hashcat.potfile")
+  local -a hc_opts=(-a 0 -m 22000 --status --status-timer=5 --session wifipen --potfile-path "${LOG_DIR}/hashcat.potfile")
 
   # GPU / CPU tuning
   case "$archcap" in
@@ -190,12 +201,11 @@ _run_hashcat_22000() {
   local log_file="$TMP_DIR/hashcat_$(date +%s).log"
   log "${GREEN}[+] Launching Hashcat with tuned options: ${hc_opts[*]}${NC}"
   
-  # Test hashcat with dry run first
-  if ! hashcat "${hc_opts[@]}" --stdout "$hcfile" "$wordlist" >/dev/null 2>&1; then
-    log "${RED}[!] Hashcat test failed. Check your input files.${NC}"
+  if [[ ! -s "$hcfile" || ! -s "$wordlist" ]]; then
+    log "${RED}[!] Hash file or wordlist missing/empty.${NC}"
     return 1
   fi
-  
+
   # Run hashcat for real
   ( hashcat "${hc_opts[@]}" "$hcfile" "$wordlist" | tee "$log_file" ) &
   _hashcat_pid=$!
@@ -364,8 +374,12 @@ crack_handshake() {
         read -r -p "Press Enter to continue..."
         return 1
       fi
+      if ! is_tool_installed aircrack-ng; then
+        log "${RED}[!] Aircrack-ng is not installed.${NC}"
+        read -r -p "Press Enter to continue..."
+        return 1
+      fi
       log "${GREEN}[+] Running aircrack-ng ...${NC}"
-      # Remove the || true to see actual errors
       if aircrack-ng -w "$WORDLIST" "$capfile"; then
         log "${GREEN}[+] Aircrack-ng completed successfully${NC}"
       else

--- a/wifi_audit/dependencies.sh
+++ b/wifi_audit/dependencies.sh
@@ -212,5 +212,15 @@ check_dependencies() {
     build_hcx_tools_from_source "$pm" || { log "${RED}[!] Failed to build hcxtools.${NC}"; return 1; }
   fi
 
+  # Final verification for cracking tools
+  for t in aircrack-ng hashcat "$JOHN_JUMBO_BIN"; do
+    if command -v "$t" >/dev/null 2>&1; then
+      log "${GREEN}[+] Found: $t${NC}"
+    else
+      log "${RED}[!] Missing: $t${NC}"
+    fi
+  done
+  [[ -n "${WPAPCAP2JOHN_BIN:-}" ]] || log "${YELLOW}[!] wpapcap2john not found – .cap→.john conversion will be skipped.${NC}"
+
   log "${GREEN}[+] All critical dependencies installed and verified.${NC}"
 }


### PR DESCRIPTION
## Summary
- add verify_handshake using hcxpcapngtool and aircrack-ng
- harden John and Hashcat cracking flows with better dependency checks
- confirm core wireless tools after dependency installation

## Testing
- `bash -n wifi_audit/capture_handler.sh`
- `bash -n wifi_audit/crack_handler.sh`
- `bash -n wifi_audit/dependencies.sh`


------
https://chatgpt.com/codex/tasks/task_e_689fff14fe30832f88964ac76a46bd83